### PR TITLE
fix ordering of modules

### DIFF
--- a/src/services/loading-files.js
+++ b/src/services/loading-files.js
@@ -44,6 +44,8 @@ export function createProjectStructure(mainFile) {
   let orderedModNames = modules.map((m) => m.name)
 
   for (let i = 0; i < modules.length; i++) {
+    if (modules[i].content || !fs.existsSync(modules[i].path)) continue
+
     modules[i].content = fs.readFileSync(modules[i].path, 'utf-8')
 
     const requiresInMod = findRequires(modules[i].content)

--- a/src/services/loading-files.js
+++ b/src/services/loading-files.js
@@ -51,7 +51,7 @@ export function createProjectStructure(mainFile) {
     requiresInMod.forEach((mod) => {
       const existingMod = modules.find((m) => m.name === mod.name)
       if (!existingMod) {
-        modules = modules.push(mod)
+        modules.push(mod)
       }
 
       const existingName = orderedModNames.find((name) => name === mod.name)

--- a/src/services/loading-files.js
+++ b/src/services/loading-files.js
@@ -71,7 +71,7 @@ export function createProjectStructure(mainFile) {
   // is already loaded into aos
   let orderedModules = []
   for (let i = orderedModNames.length; i > 0; i--) {
-    mod = modules.find((m) => m.name == orderedModNames[i-1])
+    const mod = modules.find((m) => m.name == orderedModNames[i-1])
     if (mod && mod.content) {
       orderedModules.push(mod)
     }


### PR DESCRIPTION
I used a helper array with module names `orderedModNames`, to keep track of the order of the modules while still loading all the contents in the `modules` array.

That way, we won't skip items in `modules` while pushing modules to the end of the array, and we can modify the order with names as we please.

When all the `modules` have been loaded with the content, we create an array of modules with the correct order (it's not the most elegant way, but it gets the job done).